### PR TITLE
Enables user to define which modules to use

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -8,7 +8,7 @@ module DeviseTokenAuth::Concerns::User
 
     # Only enables modules if the user didn't
     unless self.method_defined?(:devise_modules)
-      devise :database_authenticatable, :registerable, :recoverable
+      devise :database_authenticatable, :registerable, :recoverable,
              :trackable, :validatable, :confirmable, :omniauthable
     end
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -6,11 +6,11 @@ module DeviseTokenAuth::Concerns::User
   included do
     include Mongoid::Locker
 
-    # Include default devise modules. Others available are:
-    # :confirmable, :lockable, :timeoutable and :omniauthable
-    devise :database_authenticatable, :registerable,
-          :recoverable, :rememberable, :trackable, :validatable,
-          :confirmable, :omniauthable
+    # Only enables modules if the user didn't
+    unless self.method_defined?(:devise_modules)
+      devise :database_authenticatable, :registerable, :recoverable
+             :trackable, :validatable, :confirmable, :omniauthable
+    end
 
     #serialize :tokens, JSON
 
@@ -178,6 +178,11 @@ module DeviseTokenAuth::Concerns::User
     self.save!
 
     return build_auth_header(token, client_id)
+  end
+
+  # Only makes user confirmable if the module is included
+  def confirmed?
+    self.devise_modules.exclude?(:confirmable) || super
   end
 
   protected


### PR DESCRIPTION
Currently, at the mongoid branch, it's not possible to define which devise modules to use.

So I ran into this same issue:
https://github.com/lynndylanhurley/devise_token_auth/issues/58#issuecomment-69002547
(Need to disable confirmable module)

I found that the original repo (at lynndylanhurley) had already implemented this feature in version 0.1.31.beta7.

I updated it for my personal use and am sharing with you.
